### PR TITLE
Fix recent commit that caused unsoundness

### DIFF
--- a/server/schedular.py
+++ b/server/schedular.py
@@ -575,6 +575,7 @@ class ParallelizationServer(net.Server):
                                     self.idle_solvers.append(solver)
                                     config.partition_count -= 1
                             node.assumed_timout = True
+                    ##+ investigate more thoroughly the impact of this elif branch for dynamic timeout mode
                     elif not config.node_timeout and len(node) == 0 and len(self.solvers(node)) == 1:
                         if round(time.time() - self.current.root.started) < 60:
                             config.node_timeout = 60

--- a/server/schedular.py
+++ b/server/schedular.py
@@ -181,8 +181,10 @@ class Solver(net.Socket):
                             print("Inconsistent result ... ")
 #                        else:
 #                            return {}, b''
-        if self.node.root.name != header[constant.NAME]:
-           return {}, b''
+        ## this fixes logging but introduces unsoudness!!!
+        ## if self.node.root.name != header[constant.NAME]:
+        if self.node.root.name != header[constant.NAME] or str(self.node.path()) != header[constant.NODE]:
+            return {}, b''
 
         del header[constant.NAME]
 


### PR DESCRIPTION
The bug was caused by commit 3a44754292da1b5138d6c02d10ee6ef92d235061
It probably caused some important messages to be ignored, leading to unsoundness.
Hence, the problem of not showing debug messages in the logging mode, that the commit previously fixed, remains.

Also added a comment to the part introduced by commit 0601fce858491ce4b9180dc9ebb4c52052656250 whose impact was also not properly investigated, but just using several tests it seems fine.

Resolves #6 